### PR TITLE
Add an alternative BOM for Canada

### DIFF
--- a/assembly-instructions/1-parts.md
+++ b/assembly-instructions/1-parts.md
@@ -8,6 +8,14 @@ Note that there are several 3D printed parts that you'll need to 3D print yourse
 
 ![Parts](images/parts.jpeg)
 
+## International BOMs
+
+If you're not located in the United States, check out alternatives BOMs that are specific to your country below. The parts are the same but prices are in a local currency and links are replaced with local supplier alternatives to avoid high shipping and import fees.
+
+* [Canada](../hardware/international_boms/ribbit_network_frog_sensor_bom_ca.csv)
+
+If your country isn't listed, consider contributing!
+
 ## Next Step
 [3D Printing](2-3d-printing.md)
 

--- a/hardware/international_boms/ribbit_network_frog_sensor_bom_ca.csv
+++ b/hardware/international_boms/ribbit_network_frog_sensor_bom_ca.csv
@@ -1,0 +1,40 @@
+Item,Quantity,Unit Price,Price,Unit Mass (g),Mass (g),Vendor,Link,Notes
+Sensors,,,,,,,,
+SCD-30 - NDIR CO2 Temperature and Humidity Sensor,1.00,$85.59,$85.59,10.00,10.00,Digikey,https://www.digikey.ca/en/products/detail/adafruit-industries-llc/4867/13627674,
+Barometer,1.00,$9.48,$9.48,2.00,2.00,Digikey,https://www.digikey.ca/en/products/detail/adafruit-industries-llc/4494/11569124,
+GPS,1.00,$19.99,$19.99,10.00,10.00,X2 Robotics,https://x2robotics.ca/gt-u7-gps-module-compatible-neo-6m-stm32-with-eeprom-antenna-for-arduino,
+,,,,,,,,
+Compute / Connectivity,,,,,,,,
+Raspberry Pi Compute Module 4 - 1GB / No MMC / No WiFi (Lite),1.00,$33.75,$33.75,9.00,9.00,PiShop,https://www.pishop.ca/product/raspberry-pi-compute-module-4-1gb-lite-cm4001000/,Purchase either the No Wifi Variant & the USB WIFI Adapter or the Wifi Variant & Antennae Kit
+TP-Link USB WiFi Adapter,1.00,$9.99,$9.99,2.00,2.00,Amazon,https://www.amazon.ca/TP-Link-TL-WN725N-Wireless-Adapter-Miniature/dp/B008IFXQFU/ref=sr_1_1?dchild=1&keywords=TL-WN725N&qid=1631234233&sr=8-1,
+Raspberry Pi Compute Module 4 - 1GB / w. WiFi / No MMC,0.00,$40.50,$0.00,9.00,0.00,PiShop,https://www.pishop.ca/product/raspberry-pi-compute-module-4-wireless-1gb-lite-cm4101000/,Purchase either the No Wifi Variant & the USB WIFI Adapter or the Wifi Variant & Antennae Kit
+Raspberry Pi Compute Module 4 Antenna Kit,0.00,$6.75,$0.00,14.00,0.00,PiShop,https://www.pishop.ca/product/2-4ghz-5-8ghz-antenna-kit-for-cm4/,
+Base Board for Raspberry Pi Compute Module 4,1.00,$46.99,$46.99,38.00,38.00,Amazon,https://www.amazon.ca/TOP1-CM4-IO-BASE-B-Raspberry-Expansion-Computing/dp/B09413V2LQ,
+16 GB SD Card (Adapter not included!),1.00,$8.95,$8.95,0.25,0.25,PiShop,https://www.pishop.ca/product/microsd-card-16-gb-class-10-blank/,
+,,,,,,,,
+Cables,,,,,,,,
+SparkFun Qwiic or Stemma QT SHIM,1.00,$1.30,$1.30,1.00,1.00,Digikey,https://www.digikey.ca/en/products/detail/sparkfun-electronics/DEV-15794/11206004,
+2x3 Female Header,1.00,$0.85,$0.85,0.25,0.25,Digikey,https://www.digikey.ca/en/products/detail/sullins-connector-solutions/PPPC032LFBN-RC/810243,
+Power Supply,1.00,$30.52,$30.52,94.00,94.00,Amazon,https://www.amazon.ca/CanaKit-Raspberry-Power-Supply-USB-C/dp/B07TYQRXTK,
+STEMMA QT / Qwiic JST SH 4-pin Cable - 50mm Long,1.00,$1.30,$1.30,0.25,0.25,Digikey,https://www.digikey.ca/en/products/detail/sparkfun-electronics/PRT-17260/13629028,
+STEMMA QT / Qwiic JST SH 4-pin Cable - 100mm Long,1.00,$2.13,$2.13,0.25,0.25,Digikey,https://www.digikey.ca/en/products/detail/sparkfun-electronics/PRT-14427/7652740,
+GPS USB Cable,1.00,$6.99,$6.99,2.00,2.00,Amazon,https://www.amazon.ca/AmazonBasics-Male-Micro-Cable-Black/dp/B0711PVX6Z/ref=sr_1_20?dchild=1&keywords=micro%2Busb%2Bcable&qid=1631236137&s=electronics&sr=1-20&th=1,
+,,,,,,,,
+Mechanical,,,,,,,,
+Enclosure,1.00,$22.21,$22.21,220.00,220.00,Amazon,https://www.amazon.ca/AcuRite-06054M-Temperature-Humidity-Radiation/dp/B01M64ISDE,
+Brass Standoffs,11.00,$0.55,$4.29,0.50,6.05,Digikey,https://www.digikey.ca/en/products/detail/würth-elektronik/971050154/9488600?s=N4IgTCBcDaIJwHYCMAGArCpaAsIC6AvkA,
+M2.5 x 5 Screws,11.00,$0.20,$2.20,0.25,2.75,Digikey,https://www.digikey.ca/en/products/detail/essentra-components/50M025045P005/11639454,
+,,,,,,,,
+3D Printed Parts,,,,,,,,Quantity shows percentage of a filament roll used for each part
+Electronics Bracket,0.10,$23.95,$2.40,84.00,8.40,3D Printing Canada,https://3dprintingcanada.com/products/dark-green-1-75mm-petg-filament-1-kg?_pos=2&_sid=1fcd731fc&_ss=r,https://github.com/Ribbit-Network/ribbit-network-frog-sensor/tree/main/hardware/mechanical
+Frog Eyes,0.02,$23.95,$0.48,2.00,0.04,3D Printing Canada,https://3dprintingcanada.com/products/black-1-75mm-petg-filament-1-kg?_pos=10&_sid=455fc3519&_ss=r,https://github.com/Ribbit-Network/ribbit-network-frog-sensor/tree/main/hardware/mechanical
+Frog Mouth,0.01,$39.95,$0.40,1.00,0.01,3D Printing Canada,https://3dprintingcanada.com/collections/petg/products/fuchsia-1-75mm-sakata-petg-filament-1-kg,https://github.com/Ribbit-Network/ribbit-network-frog-sensor/tree/main/hardware/mechanical
+Frog Head,0.11,$23.95,$2.63,60.00,6.60,3D Printing Canada,https://3dprintingcanada.com/products/dark-green-1-75mm-petg-filament-1-kg?_pos=2&_sid=1fcd731fc&_ss=r,https://github.com/Ribbit-Network/ribbit-network-frog-sensor/tree/main/hardware/mechanical
+GPS Clip,0.05,$23.95,$1.20,4.00,0.20,3D Printing Canada,https://3dprintingcanada.com/products/dark-green-1-75mm-petg-filament-1-kg?_pos=2&_sid=1fcd731fc&_ss=r,https://github.com/Ribbit-Network/ribbit-network-frog-sensor/tree/main/hardware/mechanical
+,,,,,,,,
+Consumables,,,,,,,,
+Two Part Epoxy,0.10,$8.96,$0.90,0.00,0.00,Amazon,https://www.amazon.ca/Loctite-1365868-Minute-Instant-Adhesive/dp/B0044F9KFI/ref=sr_1_1?dchild=1&keywords=Loctite+Epoxy+Five+Minute+Instant+Mix&qid=1631465912&sr=8-1,
+Loctite,0.10,$9.99,$1.00,0.00,0.00,Amazon,https://www.amazon.ca/Loctite-Locking-Compound-Removable-303379/dp/B019GIS13O/ref=sr_1_2?dchild=1&keywords=Loctite+Blue+242&qid=1631465863&sr=8-2,
+Green Paint,0.20,$8.87,$3.00,0.00,0.00,Amazon,https://www.amazon.ca/Tremclad-27029b522-Rust-Paint/dp/B075S6G51L/ref=sr_1_2?dchild=1&keywords=TREMCLAD+green&qid=1631466742&sr=8-2,
+,,,,,,,,
+Parts Total,,,$298.54,,412.50,,,


### PR DESCRIPTION
@eren-rudy and I are buying some parts to put together a prototype here, but the links in the current BOM are US-based companies. So I did some work to put together an alternative BOM with Canadian-based suppliers and figured it would be a helpful jumping off point for anyone else based in Canada interested in making their own sensor.

I tried to keep parts identical but there are a few alternates (paint, printer filament, etc.) that I can't personally endorse since I haven't actually bought them. Also, there is probably some optimization for cheaper alternatives but I tried to minimize the number of different vendors to make purchasing a bit easier.

The downside of multiple BOMs is an increased number of files to update when updating the hardware revisions, so I guess keep that in mind. But I think it's worth it to increase accessibility. :)
