### PR TITLE
Beaglebone Black Support

### DIFF
--- a/software/co2/Dockerfile.template
+++ b/software/co2/Dockerfile.template
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python
+FROM balenalib/%%BALENA_MACHINE_NAME%%-python:buster
 
 RUN install_packages vim build-essential wget gpsd-clients dbus
 

--- a/software/co2/Dockerfile.template
+++ b/software/co2/Dockerfile.template
@@ -25,7 +25,7 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-python:buster
 RUN install_packages vim build-essential wget gpsd-clients dbus
 
 # Install Python Packages
-RUN pip install RPi.GPIO==0.7.1a4
+RUN pip install RPi.GPIO==0.7.1a4 Adafruit_BBIO
 RUN pip install smbus adafruit-circuitpython-scd30 influxdb-client paho-mqtt requests gpsd-py3 adafruit-circuitpython-ina219 adafruit-circuitpython-lc709203f adafruit-circuitpython-dps310
 RUN pip install numpy --upgrade
 


### PR DESCRIPTION
Addresses build issue raised during Beaglebone Black investigation documented in #62.

The fix is to downgrade the version of Debian running in the co2 container to track the version released in the official Beaglebone images.