### PR TITLE
Enable i2c-gpio on rasbperry pi

### DIFF
--- a/software/co2/Dockerfile.template
+++ b/software/co2/Dockerfile.template
@@ -26,7 +26,7 @@ RUN install_packages vim build-essential wget gpsd-clients dbus
 
 # Install Python Packages
 RUN pip install RPi.GPIO==0.7.1a4 Adafruit_BBIO
-RUN pip install smbus adafruit-circuitpython-scd30 influxdb-client paho-mqtt requests gpsd-py3 adafruit-circuitpython-ina219 adafruit-circuitpython-lc709203f adafruit-circuitpython-dps310
+RUN pip install smbus adafruit-circuitpython-scd30 influxdb-client paho-mqtt requests gpsd-py3 adafruit-circuitpython-ina219 adafruit-circuitpython-lc709203f adafruit-circuitpython-dps310 adafruit-extended-bus
 RUN pip install numpy --upgrade
 
 # This will copy all files in our root to the working  directory in the container

--- a/software/co2/co2.py
+++ b/software/co2/co2.py
@@ -30,6 +30,8 @@ import os
 import json
 import gpsd
 
+from adafruit_extended_bus import ExtendedI2C as I2C
+
 from influxdb_client import InfluxDBClient, Point, WritePrecision
 from influxdb_client.client.write_api import SYNCHRONOUS
 
@@ -51,7 +53,7 @@ org = "keenan.johnson@gmail.com"
 
 write_api = client.write_api(write_options=SYNCHRONOUS)
 
-i2c_bus = board.I2C()
+i2c_bus = I2C(11)
 scd = adafruit_scd30.SCD30(i2c_bus)
 time.sleep(1)
 scd.ambient_pressure = 1007


### PR DESCRIPTION
Fixes #61. This change enables i2c-gpio (software i2c) for raspberry pi boards instead of the hardware i2c to work around a bug in the clock stretching in hardware i2c. Clock stretching is required by the co2 sensor (SCD30).
