### PR TITLE
[software/co2] Shrink Docker image using multi-stage build

### DIFF
--- a/software/.dockerignore
+++ b/software/.dockerignore
@@ -1,1 +1,2 @@
 */Dockerfile.template
+*/Dockerfile

--- a/software/co2/.gitignore
+++ b/software/co2/.gitignore
@@ -177,3 +177,7 @@ cython_debug/
 # Support for Project snippet scope
 
 # End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode
+
+# Dockerfile can be used for local testing, but shouldn't be committed
+# to avoid confusion as production ONLY cares about Dockerfile.template
+Dockerfile

--- a/software/co2/Dockerfile.template
+++ b/software/co2/Dockerfile.template
@@ -20,16 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python:buster
+FROM balenalib/%%BALENA_MACHINE_NAME%%-python:buster-build AS build
 
-RUN install_packages \
-    vim \
-    wget \
-    build-essential \
+RUN install_packages -y --no-install-recommends \
     gpsd-clients \
     dbus 
 
-# Get ready to install Python packages
+# Set up and activate the virtualenv
+RUN python -m venv /usr/venv 
+ENV PATH="/usr/venv/bin:$PATH" VIRTUAL_ENV=/usr/venv
+
+# Prepare our Python toolchain
 RUN pip install wheel
 RUN pip install pip --upgrade
 
@@ -39,11 +40,36 @@ RUN pip install RPi.GPIO==0.7.1a4 Adafruit_BBIO
 
 # Set our working directory
 WORKDIR /usr/src/
-# This will copy all files in our root to the working  directory in the container
-# It's almost guaranteed to bust the Docker build cache, so do it as late as possible
-COPY . ./
-
+# Copy in just enough to install dependencies
+COPY pyproject.toml poetry.lock ./
 # Install Python packages; dependencies from pyproject.toml via poetry-core / PEP 517
-RUN pip install .
+# Create an empty co2.py so that pip is not confused
+RUN touch co2.py && pip install .
+# Save a tiny amount of space: we don't need `wheel` at runtime
+# We also don't need our own package in the virtualenv, we'll run from source
+RUN pip uninstall -y wheel co2
+# Shipping .pyc files doesn't gain us anything, and it costs space
+RUN find /usr/venv -name '*.pyc' -delete
+
+########################
+# END OF `build` STAGE #
+########################
+
+FROM balenalib/%%BALENA_MACHINE_NAME%%-python:buster-run
+
+RUN install_packages -y --no-install-recommends \
+    # Runtime dependencies
+    gpsd-clients \
+    dbus \
+    # Convenience tools
+    vim
+
+# Grab the virtualenv and activate it
+COPY --from=build /usr/venv /usr/venv
+ENV PATH="/usr/venv/bin:$PATH" VIRTUAL_ENV=/usr/venv
+
+# Get the source
+WORKDIR /usr/src/
+COPY . ./
 
 CMD python co2.py


### PR DESCRIPTION
Part of #80. This takes the `co2` image on `beaglebone-green-gateway` from 540MB to 410MB.

Special point of interest: Balena provides `-build` and `-run` images (see https://www.balena.io/docs/reference/base-images/base-images/#run-vs-build). We're now explicitly using them. In practice this just means we get to not manually install `build-essentials` and such, but seems like good practice anyway.

Tested on `test-bbb-green/lingering-jam`.