### PR TITLE
Update live data link to new dashboard.ribbitnetwork.org

### DIFF
--- a/v1/assembly-instructions/7-sensor-placement.md
+++ b/v1/assembly-instructions/7-sensor-placement.md
@@ -30,7 +30,7 @@ If you didn't enter your home network WiFi information previously, or you purcha
 * Once you have entered your WiFi information, you should see the following message appear on the page: *"Note! Applying changes... Your device will soon be online. If connection is unsuccessful, the Access Point will be back up in a few minutes, and reloading this page will allow you to try again."*
   * If you receive the error message: *"Danger! Fail to connect to the network. NetworkError when attempting to fetch resource.* Unplug the power cable from the frog sensor, wait 30 seconds, then plug it back in to force it to restart. Then try the above steps again. (See additional help resources [here](#need-help))
 * The sensor will now disconnect from your device, stop broadcasting the "WiFi Connect" hotspot, and connect to your home WiFi network. 
-* You should see the Frog sensor appear on the [web page here shortly](https://ribbit-network.herokuapp.com/). 
+* You should see the Frog sensor appear on the [web page here shortly](https://dashboard.ribbitnetwork.org/). 
 
 If there are any connection problems, the sensor will restart and broadcast the Wifi Connect hotspot again.
 

--- a/v1/assembly-instructions/8-done.md
+++ b/v1/assembly-instructions/8-done.md
@@ -2,7 +2,7 @@
 
 Congrats, you're done! The Frog Sensor is complete and collecting data for our planet.
 
-[You can view the live data from your sensor here.](https://ribbit-network.herokuapp.com/)
+[You can view the live data from your sensor here.](https://dashboard.ribbitnetwork.org/)
 
 If you don't see your sensor on the map linked above, [see the debugging steps here.](9-debugging.md)
 

--- a/v2/assembly-instructions/5-sensor-placement.md
+++ b/v2/assembly-instructions/5-sensor-placement.md
@@ -30,7 +30,7 @@ If you didn't enter your home network WiFi information previously, or you purcha
 * Once you have entered your WiFi information, you should see the following message appear on the page: *"Note! Applying changes... Your device will soon be online. If connection is unsuccessful, the Access Point will be back up in a few minutes, and reloading this page will allow you to try again."*
   * If you receive the error message: *"Danger! Fail to connect to the network. NetworkError when attempting to fetch resource.* Unplug the power cable from the frog sensor, wait 30 seconds, then plug it back in to force it to restart. Then try the above steps again. (See additional help resources [here](#need-help))
 * The sensor will now disconnect from your device, stop broadcasting the "WiFi Connect" hotspot, and connect to your home WiFi network. 
-* You should see the Frog sensor appear on the [web page here shortly](https://ribbit-network.herokuapp.com/). 
+* You should see the Frog sensor appear on the [web page here shortly](https://dashboard.ribbitnetwork.org/). 
 
 If there are any connection problems, the sensor will restart and broadcast the Wifi Connect hotspot again.
 

--- a/v2/assembly-instructions/6-done.md
+++ b/v2/assembly-instructions/6-done.md
@@ -2,7 +2,7 @@
 
 Congrats, you're done! The Frog Sensor is complete and collecting data for our planet.
 
-[You can view the live data from your sensor here.](https://ribbit-network.herokuapp.com/)
+[You can view the live data from your sensor here.](https://dashboard.ribbitnetwork.org/)
 
 If you don't see your sensor on the map linked above, [see the debugging steps here.](7-debugging.md)
 

--- a/v3/assembly-instructions/5-sensor-placement.md
+++ b/v3/assembly-instructions/5-sensor-placement.md
@@ -30,7 +30,7 @@ If you didn't enter your home network WiFi information previously, or you purcha
 * Once you have entered your WiFi information, you should see the following message appear on the page: *"Note! Applying changes... Your device will soon be online. If connection is unsuccessful, the Access Point will be back up in a few minutes, and reloading this page will allow you to try again."*
   * If you receive the error message: *"Danger! Fail to connect to the network. NetworkError when attempting to fetch resource.* Unplug the power cable from the frog sensor, wait 30 seconds, then plug it back in to force it to restart. Then try the above steps again. (See additional help resources [here](#need-help))
 * The sensor will now disconnect from your device, stop broadcasting the "WiFi Connect" hotspot, and connect to your home WiFi network. 
-* You should see the Frog sensor appear on the [web page here shortly](https://ribbit-network.herokuapp.com/). 
+* You should see the Frog sensor appear on the [web page here shortly](https://dashboard.ribbitnetwork.org/). 
 
 If there are any connection problems, the sensor will restart and broadcast the Wifi Connect hotspot again.
 

--- a/v3/assembly-instructions/6-done.md
+++ b/v3/assembly-instructions/6-done.md
@@ -2,7 +2,7 @@
 
 Congrats, you're done! The Frog Sensor is complete and collecting data for our planet.
 
-[You can view the live data from your sensor here.](https://ribbit-network.herokuapp.com/)
+[You can view the live data from your sensor here.](https://dashboard.ribbitnetwork.org/)
 
 If you don't see your sensor on the map linked above, [see the debugging steps here.](7-debugging.md)
 


### PR DESCRIPTION
Update the directions to point to https://dashboard.ribbitnetwork.org/ instead of the old herokuapp link.